### PR TITLE
順位判定機能の修正

### DIFF
--- a/Assets/M/Scripts/m_CheckPoint.cs
+++ b/Assets/M/Scripts/m_CheckPoint.cs
@@ -59,7 +59,7 @@ public class m_CheckPoint : MonoBehaviour
             else if (checkPointAfter.ranking.IndexOf(collision) >= 0)
             {
                 checkPointAfter.ranking.Remove(collision);
-                checkPointBefore.ranking.Add(collision);
+                ranking.Add(collision);
             }
             else if (ranking.IndexOf(collision) >= 0)
             {
@@ -71,6 +71,8 @@ public class m_CheckPoint : MonoBehaviour
                 {
                     ranking.Add(collision);
                     checkPointManager.addedCollider.Add(collision, true);
+                    if (!checkPointManager.carLapCount.ContainsKey(collision)) checkPointManager.carLapCount.Add(collision, 0);
+                    if (pointIndex != 0) checkPointManager.carLapCount[collision]--;
                 }
             }
         }


### PR DESCRIPTION
戻るときに、チェックポイントを１つ以上飛ばして通過しても良いように改良
戻ると一時的に順位の表示がおかしくなる